### PR TITLE
fix_debug_detach. Added debug detach on engine destruction to prevent…

### DIFF
--- a/src/duktape_engine.cpp
+++ b/src/duktape_engine.cpp
@@ -280,6 +280,14 @@ public:
 
     }
 
+    ~impl(){
+        // try to detach context from debugger
+        if (debug_transport.is_active()) {
+            auto ctx = dukctx.get();
+            duk_debugger_detach(ctx);
+        }
+    }
+
     support::buffer run_callback_script(duktape_engine&, sl::io::span<const char> callback_script_json) {
         auto ctx = dukctx.get();
         auto def = sl::support::defer([ctx]() STATICLIB_NOEXCEPT {


### PR DESCRIPTION
… debugger calls to destroyed object.